### PR TITLE
update javascript path parsing code to handle . within path itself

### DIFF
--- a/script.js
+++ b/script.js
@@ -99,7 +99,7 @@ function init(options) {
 	for( const key of Object.keys(options) ) {
 		if( !options[key] || !( key in fileLocations)) continue;
 		for( const location of fileLocations[key] ) {
-			const [,type] = location.split('.');
+			const type = location.substr((~-location.lastIndexOf(".") >>> 0) + 2);
 			loading.push({location, type});
 		}
 	}


### PR DESCRIPTION
My own fork is exposing all languages supported by code mirror and there's an ASN.1 path in there that was causing code to break. This code fixes that issue. Code taken from stackoverflow:

[Answer: How can I get file extensions with JavaScript?](http://stackoverflow.com/a/1203361/504757)